### PR TITLE
Update useUploadFiles.mdx

### DIFF
--- a/docs/pages/api-reference/useUploadFiles.mdx
+++ b/docs/pages/api-reference/useUploadFiles.mdx
@@ -17,7 +17,7 @@ An example use case is shown below, **try it out**!
 
 ```tsx filename="src/App.tsx"
 import { useMutation } from "convex/react";
-import { useUploadFiles } from "@xixixao/uploadstuff";
+import { useUploadFiles } from "@xixixao/uploadstuff/react";
 import { api } from "../convex/_generated/api";
 
 export function App() {


### PR DESCRIPTION
## Description
The documentation for the `@xixixao/uploadstuff` library currently contains an error in the example source code provided. The `useUploadFiles` hook is shown as being imported directly from `@xixixao/uploadstuff`, but when attempting to use this import, TypeScript throws an error:

'"@xixixao/uploadstuff"' has no exported member named 'useUploadFiles'. Did you mean 'uploadFiles'?ts(2724)

This leads to confusion and potential issues when attempting to use the library according to the documentation.

## Expected Behavior
The import statement in the documentation should reflect the actual exported member from the correct package. If `useUploadFiles` is indeed exported from a different package, such as `@xixixao/uploadstuff/react`, the documentation should be updated accordingly to prevent any misunderstanding.

## Steps to Reproduce
1. Attempt to import `useUploadFiles` from `@xixixao/uploadstuff` as shown in the documentation.
2. Observe the TypeScript error indicating that `useUploadFiles` is not an exported member.

## Possible Solution
Updated the documentation to show the correct import path. If `useUploadFiles` is exported from `@xixixao/uploadstuff/react`, the import statement should be:

```typescript
import { useUploadFiles } from "@xixixao/uploadstuff/react";
```

Thank you for considering this PR. I believe correcting this will make the documentation clearer for future users of the library.
