### PR TITLE
fix(useRef): initialize `stableRef` with `null` to comply with React 19 requirements

### DIFF
--- a/lib/useEvent.ts
+++ b/lib/useEvent.ts
@@ -35,7 +35,7 @@ export function useEvent<TCallback extends AnyFunction>(
 
   // Create a stable callback that always calls the latest callback:
   // using useRef instead of useCallback avoids creating and empty array on every render
-  const stableRef = useRef<TCallback>();
+  const stableRef = useRef<TCallback | null>(null);
   if (!stableRef.current) {
     stableRef.current = function (this: unknown) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return, prefer-rest-params, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any


### PR DESCRIPTION
fix(useRef): initialize `stableRef` with `null` to comply with React 19 requirements

Updated `useRef` initialization for `stableRef` to include a `null` argument, as React 19 now requires an initial argument for the `useRef` hook. This ensures compatibility with the updated React API.

relate to: [issue #16](https://github.com/get-convex/uploadstuff/issues/16)